### PR TITLE
Searching for pets for an application ss

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -2,6 +2,7 @@ class ApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:id])
     @pets = @application.pets
+    @searched_pets = Pet.search(params[:search]) if params[:search].present?
   end
 
   def new

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -9,10 +9,23 @@
 <p>Applying for: </p>
 <% @pets.each do |pet| %>
 <%=link_to "#{pet.name}", "/pets/#{pet.id}" %></p>
-<% end %>
+<% end %><br>
 
 <% if @application.status == "In Progress" %>
-  <h3>Add a Pet to this Application</h3
-<% end%>
+  <h3>Add a Pet to this Application</h3>
+  <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |form| %>
+    <%= form.label :search %>
+    <%= form.text_field :search %>
+    <%= form.submit "Search" %>
+  <% end %>
+<% end %><br>
 
-<p>Status: <%= @application.status %></p>
+<% if !@searched_pets.nil? %>
+  <% @searched_pets.each do |pet| %>
+    <h4><%= pet.name %></h4>
+    <p><%= "Breed: #{pet.breed}" %></p>
+    <p><%= "Age: #{pet.age}" %></p>
+  <% end %>
+<% end %><br>
+
+<h3>Status: <%= @application.status %></h3>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -5,8 +5,14 @@
 <p>State: <%= @application.state %></p>
 <p>Zip Code: <%= @application.zip %></p>
 <p>Description: <%= @application.description %></p>
+
 <p>Applying for: </p>
 <% @pets.each do |pet| %>
 <%=link_to "#{pet.name}", "/pets/#{pet.id}" %></p>
 <% end %>
+
+<% if @application.status == "In Progress" %>
+  <h3>Add a Pet to this Application</h3
+<% end%>
+
 <p>Status: <%= @application.status %></p>

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe '/applications/:id', type: :feature do
       state: 'MI', 
       zip: '45896', 
       description: 'Loves alligators.', 
-      status: 'Pending'
+      status: 'Accepted'
     )
 
     @tom = Application.create!(
@@ -86,6 +86,20 @@ RSpec.describe '/applications/:id', type: :feature do
       
       click_link("#{@pet_2.name}")
       expect(current_path).to eq("/pets/#{@pet_2.id}")
+
+    end
+  end
+
+  # User Story 4
+  describe "Searching for Pets for an Applicatioin" do
+    it "displays an 'Add a Pet' section if the application has not been submitted (status = 'In Progress')" do 
+      visit "/applications/#{@tom.id}"
+      expect(page).to have_content("Status: In Progress")
+      expect(page).to have_content("Add a Pet to this Application")
+
+      visit "/applications/#{@susie.id}"
+      expect(page).to have_content("Status: Accepted")
+      expect(page).to_not have_content("Add a Pet to this Application")
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe '/applications/:id', type: :feature do
     @pet_1 = @shelter_1.pets.create!(name: "Mr. Pirate", breed: "tuxedo shorthair", age: 5, adoptable: true)
     @pet_2 = @shelter_1.pets.create!(name: "Clawdia", breed: "shorthair", age: 3, adoptable: true)
     @pet_3 = @shelter_1.pets.create!(name: "Ann", breed: "ragdoll", age: 3, adoptable: false)
+    @pet_4 = @shelter_1.pets.create!(name: "Fluffy", breed: "british shorthair", age: 1, adoptable: true)
 
     @susie = Application.create!(
       name: 'Susie', 
@@ -100,6 +101,32 @@ RSpec.describe '/applications/:id', type: :feature do
       visit "/applications/#{@susie.id}"
       expect(page).to have_content("Status: Accepted")
       expect(page).to_not have_content("Add a Pet to this Application")
+    end
+
+    it "successfully searches for a pet by name and display it below search bar" do
+      visit "/applications/#{@tom.id}"
+      expect(page).to have_content("Add a Pet to this Application")
+      expect(page).to have_button("Search")
+      expect(page).to_not have_content(@pet_4.name)
+      
+      fill_in("Search", with: @pet_4.name)
+      click_button("Search")
+
+      expect(current_path).to eq("/applications/#{@tom.id}")
+      expect(page).to have_content(@pet_4.name)
+    end
+
+    it "unsuccessfully searches for a pet by name and does not display it" do
+      visit "/applications/#{@tom.id}"
+      expect(page).to have_content("Add a Pet to this Application")
+      expect(page).to have_button("Search")
+      expect(page).to_not have_content("Spot")
+      
+      fill_in("Search", with: "Spot")
+      click_button("Search")
+
+      expect(current_path).to eq("/applications/#{@tom.id}")
+      expect(page).to_not have_content("Spot")
     end
   end
 end


### PR DESCRIPTION
This pull request completes user story 4:
- Adds a pet search bar on the Application show page **if** the status of application is "In Progress" ("In Progress" is the default status for a newly created Application. Will assume the other three status: "Pending", "Accepted", "Rejected" are for when the adoption application has been submitted for consideration.
- If the applicant successfully searches for a pet by name (can be either the full name of a pet or just a partial match), then the pet result is displayed on the Show page **below** the search bar